### PR TITLE
Omni channels modif

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/cellpose/CellposeDetector.java
+++ b/src/main/java/fiji/plugin/trackmate/cellpose/CellposeDetector.java
@@ -42,7 +42,6 @@ import fiji.plugin.trackmate.omnipose.advanced.AdvancedOmniposeSettings;
 import fiji.plugin.trackmate.util.TMUtils;
 import ij.IJ;
 import ij.ImagePlus;
-import ij.ImageStack;
 import ij.gui.NewImage;
 import ij.plugin.Concatenator;
 import ij.plugin.Duplicator;

--- a/src/main/java/fiji/plugin/trackmate/cellpose/CellposeDetector.java
+++ b/src/main/java/fiji/plugin/trackmate/cellpose/CellposeDetector.java
@@ -38,11 +38,14 @@ import fiji.plugin.trackmate.TrackMate;
 import fiji.plugin.trackmate.detection.DetectionUtils;
 import fiji.plugin.trackmate.detection.LabelImageDetectorFactory;
 import fiji.plugin.trackmate.detection.SpotGlobalDetector;
+import fiji.plugin.trackmate.omnipose.advanced.AdvancedOmniposeSettings;
 import fiji.plugin.trackmate.util.TMUtils;
 import ij.IJ;
 import ij.ImagePlus;
+import ij.ImageStack;
 import ij.gui.NewImage;
 import ij.plugin.Concatenator;
+import ij.plugin.Duplicator;
 import ij.process.ImageConverter;
 import ij.process.StackConverter;
 import net.imagej.ImgPlus;
@@ -556,7 +559,13 @@ public class CellposeDetector< T extends RealType< T > & NativeType< T > > imple
 			for ( final ImagePlus imp : imps )
 			{
 				final String name = imp.getShortTitle() + ".tif";
-				IJ.saveAsTiff( imp, Paths.get( tmpDir.toString(), name ).toString() );
+                                // If we are running an advanced omnipose detector, just save the segmentation channel as tmp image
+                                if (cellposeSettings instanceof AdvancedOmniposeSettings) {
+                                    ImagePlus chanImp = new Duplicator().run(imp, cellposeSettings.chan, cellposeSettings.chan, 0, 0, 0, 0);
+                                    IJ.saveAsTiff( chanImp, Paths.get( tmpDir.toString(), name ).toString() );
+                                } else {
+                                    IJ.saveAsTiff( imp, Paths.get( tmpDir.toString(), name ).toString() );
+                                }
 			}
 
 			/*

--- a/src/main/java/fiji/plugin/trackmate/omnipose/advanced/AdvancedOmniposeDetectorConfigurationPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/omnipose/advanced/AdvancedOmniposeDetectorConfigurationPanel.java
@@ -2,6 +2,7 @@ package fiji.plugin.trackmate.omnipose.advanced;
 
 import static fiji.plugin.trackmate.cellpose.advanced.AdvancedCellposeDetectorFactory.KEY_CELL_PROB_THRESHOLD;
 import static fiji.plugin.trackmate.cellpose.advanced.AdvancedCellposeDetectorFactory.KEY_FLOW_THRESHOLD;
+import static fiji.plugin.trackmate.omnipose.advanced.AdvancedOmniposeDetectorFactory.KEY_NB_CLASSES;
 import static fiji.plugin.trackmate.gui.Fonts.SMALL_FONT;
 
 import java.awt.GridBagConstraints;
@@ -13,11 +14,16 @@ import javax.swing.JLabel;
 import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.Settings;
 import fiji.plugin.trackmate.detection.SpotDetectorFactoryBase;
+import static fiji.plugin.trackmate.gui.Fonts.SMALL_FONT;
 import fiji.plugin.trackmate.gui.GuiUtils;
 import fiji.plugin.trackmate.gui.displaysettings.SliderPanelDouble;
 import fiji.plugin.trackmate.gui.displaysettings.StyleElements;
 import fiji.plugin.trackmate.omnipose.OmniposeDetectorConfigurationPanel;
 import fiji.plugin.trackmate.omnipose.OmniposeSettings.PretrainedModelOmnipose;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Vector;
+import javax.swing.JComboBox;
 
 public class AdvancedOmniposeDetectorConfigurationPanel extends OmniposeDetectorConfigurationPanel
 {
@@ -25,6 +31,8 @@ public class AdvancedOmniposeDetectorConfigurationPanel extends OmniposeDetector
 	private static final long serialVersionUID = 1L;
 
 	private static final String TITLE = AdvancedOmniposeDetectorFactory.NAME;;
+        
+        protected final JComboBox< String > cmbboxNbClasses;
 
 	private final StyleElements.BoundedDoubleElement flowThresholdEl = new StyleElements.BoundedDoubleElement( "Flow threshold", 0.0, 3.0 )
 	{
@@ -65,13 +73,46 @@ public class AdvancedOmniposeDetectorConfigurationPanel extends OmniposeDetector
 	public AdvancedOmniposeDetectorConfigurationPanel( final Settings settings, final Model model )
 	{
 		super( settings, model, TITLE, ICON, DOC1_URL, "omnipose", PretrainedModelOmnipose.values() );
+                
+                int gridy = 12;
+                
+                
+                /*
+		 * Add model number of output classes.
+		 */
 
+		final JLabel lblNbClasses = new JLabel( "Number of output classes of the model:" );
+		lblNbClasses.setFont( SMALL_FONT );
+		final GridBagConstraints gbcLblNbClasses = new GridBagConstraints();
+		gbcLblNbClasses.anchor = GridBagConstraints.EAST;
+		gbcLblNbClasses.insets = new Insets( 0, 5, 5, 5 );
+		gbcLblNbClasses.gridx = 0;
+		gbcLblNbClasses.gridy = gridy;
+		mainPanel.add( lblNbClasses, gbcLblNbClasses );
+                
+                int nbClassesMin = 2;
+                int nbClassesMax = 4;
+
+		final List< String > lNbClasses = new ArrayList< String >();
+                for ( int nc = nbClassesMin; nc <= nbClassesMax; nc++ )
+                    lNbClasses.add( "" + nc );
+
+		cmbboxNbClasses = new JComboBox<>( new Vector<>( lNbClasses ) );
+		cmbboxNbClasses.setFont( SMALL_FONT );
+		final GridBagConstraints gbcSpinner = new GridBagConstraints();
+		gbcSpinner.fill = GridBagConstraints.HORIZONTAL;
+		gbcSpinner.gridwidth = 2;
+		gbcSpinner.insets = new Insets( 0, 5, 5, 5 );
+		gbcSpinner.gridx = 1;
+		gbcSpinner.gridy = gridy;
+		mainPanel.add( cmbboxNbClasses, gbcSpinner );
+
+                
 		/*
 		 * Add flow threshold.
 		 */
-
-		int gridy = 12;
-
+                gridy++;
+                   
 		final JLabel lblFlowThreshold = new JLabel( "Flow threshold:" );
 		lblFlowThreshold.setFont( SMALL_FONT );
 		final GridBagConstraints gbcLblFlowThreshold = new GridBagConstraints();
@@ -133,6 +174,7 @@ public class AdvancedOmniposeDetectorConfigurationPanel extends OmniposeDetector
 		flowThresholdEl.update();
 		cellProbThresholdEl.set( ( double ) settings.get( KEY_CELL_PROB_THRESHOLD ) );
 		cellProbThresholdEl.update();
+                cmbboxNbClasses.setSelectedIndex( (int) settings.get( KEY_NB_CLASSES ) );
 	}
 
 	@Override
@@ -141,6 +183,7 @@ public class AdvancedOmniposeDetectorConfigurationPanel extends OmniposeDetector
 		final Map< String, Object > settings = super.getSettings();
 		settings.put( KEY_FLOW_THRESHOLD, flowThresholdEl.get() );
 		settings.put( KEY_CELL_PROB_THRESHOLD, cellProbThresholdEl.get() );
+                settings.put( KEY_NB_CLASSES, cmbboxNbClasses.getSelectedIndex() + 2);
 		return settings;
 	}
 }

--- a/src/main/java/fiji/plugin/trackmate/omnipose/advanced/AdvancedOmniposeDetectorFactory.java
+++ b/src/main/java/fiji/plugin/trackmate/omnipose/advanced/AdvancedOmniposeDetectorFactory.java
@@ -85,6 +85,14 @@ public class AdvancedOmniposeDetectorFactory< T extends RealType< T > & NativeTy
 			+ "<a href=\"https://imagej.net/plugins/trackmate/trackmate-advanced-omnipose\">on the ImageJ Wiki</a>."
 			+ "</html>";
 
+         /**
+	 * The key to the parameter that store the output number of classes. 
+	 */
+        public static final String KEY_NB_CLASSES = "NB_CLASSES";
+
+	public static final Integer DEFAULT_NB_CLASSES = Integer.valueOf( 0 );
+
+        
 	/*
 	 * METHODS
 	 */
@@ -112,6 +120,7 @@ public class AdvancedOmniposeDetectorFactory< T extends RealType< T > & NativeTy
 
 		final double flowThreshold = ( Double ) settings.get( KEY_FLOW_THRESHOLD );
 		final double cellProbThreshold = ( Double ) settings.get( KEY_CELL_PROB_THRESHOLD );
+                final int nbClasses = (Integer) settings.get( KEY_NB_CLASSES );
 
 		final AdvancedOmniposeSettings cellposeSettings = AdvancedOmniposeSettings
 				.create()
@@ -125,6 +134,7 @@ public class AdvancedOmniposeDetectorFactory< T extends RealType< T > & NativeTy
 				.simplifyContours( simplifyContours )
 				.flowThreshold( flowThreshold )
 				.cellProbThreshold( cellProbThreshold )
+                                .nbClasses(nbClasses)
 				.get();
 
 		// Logger.
@@ -142,6 +152,7 @@ public class AdvancedOmniposeDetectorFactory< T extends RealType< T > & NativeTy
 		final StringBuilder errorHolder = new StringBuilder();
 		boolean ok = writeAttribute( settings, element, KEY_FLOW_THRESHOLD, Double.class, errorHolder );
 		ok = ok && writeAttribute( settings, element, KEY_CELL_PROB_THRESHOLD, Double.class, errorHolder );
+                ok = ok && writeAttribute( settings, element, KEY_NB_CLASSES, Integer.class, errorHolder );
 		if ( !ok )
 			errorMessage = errorHolder.toString();
 		return ok;
@@ -162,6 +173,7 @@ public class AdvancedOmniposeDetectorFactory< T extends RealType< T > & NativeTy
 		ok = ok && readBooleanAttribute( element, settings, KEY_SIMPLIFY_CONTOURS, errorHolder );
 		ok = ok && readDoubleAttribute( element, settings, KEY_FLOW_THRESHOLD, errorHolder );
 		ok = ok && readDoubleAttribute( element, settings, KEY_CELL_PROB_THRESHOLD, errorHolder );
+                ok = ok && readDoubleAttribute( element, settings, KEY_NB_CLASSES, errorHolder );
 
 		// Read model.
 		final String str = element.getAttributeValue( KEY_OMNIPOSE_MODEL );
@@ -187,6 +199,7 @@ public class AdvancedOmniposeDetectorFactory< T extends RealType< T > & NativeTy
 		final Map< String, Object > settings = super.getDefaultSettings();
 		settings.put( KEY_FLOW_THRESHOLD, DEFAULT_FLOW_THRESHOLD );
 		settings.put( KEY_CELL_PROB_THRESHOLD, DEFAULT_CELL_PROB_THRESHOLD );
+                settings.put( KEY_NB_CLASSES, DEFAULT_NB_CLASSES );
 		return settings;
 	}
 
@@ -205,6 +218,7 @@ public class AdvancedOmniposeDetectorFactory< T extends RealType< T > & NativeTy
 		ok = ok & checkParameter( settings, KEY_SIMPLIFY_CONTOURS, Boolean.class, errorHolder );
 		ok = ok & checkParameter( settings, KEY_FLOW_THRESHOLD, Double.class, errorHolder );
 		ok = ok & checkParameter( settings, KEY_CELL_PROB_THRESHOLD, Double.class, errorHolder );
+                ok = ok & checkParameter( settings, KEY_NB_CLASSES, Integer.class, errorHolder );
 
 		// If we have a logger, test it is of the right class.
 		final Object loggerObj = settings.get( KEY_LOGGER );
@@ -227,7 +241,8 @@ public class AdvancedOmniposeDetectorFactory< T extends RealType< T > & NativeTy
 				KEY_OMNIPOSE_CUSTOM_MODEL_FILEPATH,
 				KEY_LOGGER,
 				KEY_FLOW_THRESHOLD,
-				KEY_CELL_PROB_THRESHOLD );
+				KEY_CELL_PROB_THRESHOLD,
+                                KEY_NB_CLASSES);
 		ok = ok & checkMapKeys( settings, mandatoryKeys, optionalKeys, errorHolder );
 		if ( !ok )
 			errorMessage = errorHolder.toString();

--- a/src/main/java/fiji/plugin/trackmate/omnipose/advanced/AdvancedOmniposeSettings.java
+++ b/src/main/java/fiji/plugin/trackmate/omnipose/advanced/AdvancedOmniposeSettings.java
@@ -11,6 +11,8 @@ public class AdvancedOmniposeSettings extends OmniposeSettings
 	private final double flowThreshold;
 
 	private final double cellProbThreshold;
+        
+        private final int nbClasses;
 
 	public AdvancedOmniposeSettings(
 			final String omniposePythonPath,
@@ -22,11 +24,13 @@ public class AdvancedOmniposeSettings extends OmniposeSettings
 			final boolean useGPU,
 			final boolean simplifyContours,
 			final double flowThreshold,
-			final double cellProbThreshold )
+			final double cellProbThreshold,
+                        final int nbClasses)
 	{
 		super( omniposePythonPath, model, customModelPath, chan, chan2, diameter, useGPU, simplifyContours );
 		this.flowThreshold = flowThreshold;
 		this.cellProbThreshold = cellProbThreshold;
+                this.nbClasses = nbClasses;
 	}
 
 	@Override
@@ -41,7 +45,11 @@ public class AdvancedOmniposeSettings extends OmniposeSettings
 		 */
 		cmd.add( "--mask_threshold" );
 		cmd.add( String.valueOf( cellProbThreshold ) );
-		return Collections.unmodifiableList( cmd );
+                
+                cmd.add( "--nclasses" );
+		cmd.add( String.valueOf( nbClasses ) );
+                
+                return Collections.unmodifiableList( cmd );
 	}
 
 	public static Builder create()
@@ -51,10 +59,12 @@ public class AdvancedOmniposeSettings extends OmniposeSettings
 
 	public static final class Builder extends OmniposeSettings.Builder
 	{
-
+                
 		private double flowThreshold = 0.4;
 
 		private double cellProbThreshold = 0.0;
+                
+                private int nbClasses = 4;
 
 		public Builder flowThreshold( final double flowThreshold )
 		{
@@ -67,7 +77,13 @@ public class AdvancedOmniposeSettings extends OmniposeSettings
 			this.cellProbThreshold = cellProbThreshold;
 			return this;
 		}
-
+                
+                public Builder nbClasses( final int nbClasses )
+		{
+			this.nbClasses = nbClasses;
+			return this;
+		}
+                                
 		@Override
 		public Builder channel1( final int ch )
 		{
@@ -137,7 +153,8 @@ public class AdvancedOmniposeSettings extends OmniposeSettings
 					useGPU,
 					simplifyContours,
 					flowThreshold,
-					cellProbThreshold );
+					cellProbThreshold,
+                                        nbClasses);
 		}
 	}
 }


### PR DESCRIPTION
- Add --nclasses argument to Omnipose advanced detector to be able to run old models of omnipose with nclasses != 2
- When using omnipose advanced detector, only save the selected channel for segmentation as temp image to be able to run custom omnipose models trained on single channel images. This is also more efficient.