### PR TITLE
Modifs to use custom models with omnipose version 1.0.6

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/cellpose/AbstractCellposeSettings.java
+++ b/src/main/java/fiji/plugin/trackmate/cellpose/AbstractCellposeSettings.java
@@ -114,8 +114,6 @@ public abstract class AbstractCellposeSettings
 		 * Cellpose command line arguments.
 		 */
 
-		cmd.add( "--verbose" );
-
 		// Target dir.
 		cmd.add( "--dir" );
 		cmd.add( imagesDir );

--- a/src/main/java/fiji/plugin/trackmate/omnipose/OmniposeSettings.java
+++ b/src/main/java/fiji/plugin/trackmate/omnipose/OmniposeSettings.java
@@ -28,7 +28,7 @@ import java.util.List;
 import fiji.plugin.trackmate.cellpose.AbstractCellposeSettings;
 
 public class OmniposeSettings extends AbstractCellposeSettings
-{
+{       
 
 	public OmniposeSettings(
 			final String omniposePythonPath,
@@ -48,7 +48,11 @@ public class OmniposeSettings extends AbstractCellposeSettings
 	{
 		final List< String > cmd = new ArrayList<>( super.toCmdLine( imagesDir, is3D, anisotropy ) );
 		// omnipose executable adds it anyway, but let's make sure.
-		cmd.add( "--omni" );
+                cmd.add( "--omni" );
+                
+                cmd.add( "--nchan" );
+		cmd.add( String.valueOf( 1 ) ); // Only segment with --nchan to 1, and save only the channel to segment in temp directory
+		
 		return Collections.unmodifiableList( cmd );
 	}
 

--- a/src/main/java/fiji/plugin/trackmate/omnipose/advanced/AdvancedOmniposeDetectorConfigurationPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/omnipose/advanced/AdvancedOmniposeDetectorConfigurationPanel.java
@@ -3,8 +3,6 @@ package fiji.plugin.trackmate.omnipose.advanced;
 import static fiji.plugin.trackmate.cellpose.advanced.AdvancedCellposeDetectorFactory.KEY_CELL_PROB_THRESHOLD;
 import static fiji.plugin.trackmate.cellpose.advanced.AdvancedCellposeDetectorFactory.KEY_FLOW_THRESHOLD;
 import static fiji.plugin.trackmate.gui.Fonts.SMALL_FONT;
-import static fiji.plugin.trackmate.omnipose.advanced.AdvancedOmniposeDetectorFactory.KEY_NB_CLASSES;
-
 import java.awt.GridBagConstraints;
 import java.awt.Insets;
 import java.util.ArrayList;
@@ -31,7 +29,6 @@ public class AdvancedOmniposeDetectorConfigurationPanel extends OmniposeDetector
 
 	private static final String TITLE = AdvancedOmniposeDetectorFactory.NAME;;
 
-	protected final JComboBox< String > cmbboxNbClasses;
 
 	private final StyleElements.BoundedDoubleElement flowThresholdEl = new StyleElements.BoundedDoubleElement( "Flow threshold", 0.0, 3.0 )
 	{
@@ -74,36 +71,6 @@ public class AdvancedOmniposeDetectorConfigurationPanel extends OmniposeDetector
 		super( settings, model, TITLE, ICON, DOC1_URL, "omnipose", PretrainedModelOmnipose.values() );
 
 		int gridy = 12;
-
-		/*
-		 * Add model number of output classes.
-		 */
-
-		final JLabel lblNbClasses = new JLabel( "N. output classes:" );
-		lblNbClasses.setFont( SMALL_FONT );
-		final GridBagConstraints gbcLblNbClasses = new GridBagConstraints();
-		gbcLblNbClasses.anchor = GridBagConstraints.EAST;
-		gbcLblNbClasses.insets = new Insets( 0, 5, 5, 5 );
-		gbcLblNbClasses.gridx = 0;
-		gbcLblNbClasses.gridy = gridy;
-		mainPanel.add( lblNbClasses, gbcLblNbClasses );
-
-		final int nbClassesMin = 2;
-		final int nbClassesMax = 4;
-
-		final List< String > lNbClasses = new ArrayList< String >();
-		for ( int nc = nbClassesMin; nc <= nbClassesMax; nc++ )
-			lNbClasses.add( "" + nc );
-
-		cmbboxNbClasses = new JComboBox<>( new Vector<>( lNbClasses ) );
-		cmbboxNbClasses.setFont( SMALL_FONT );
-		final GridBagConstraints gbcSpinner = new GridBagConstraints();
-		gbcSpinner.fill = GridBagConstraints.HORIZONTAL;
-		gbcSpinner.gridwidth = 2;
-		gbcSpinner.insets = new Insets( 0, 5, 5, 5 );
-		gbcSpinner.gridx = 1;
-		gbcSpinner.gridy = gridy;
-		mainPanel.add( cmbboxNbClasses, gbcSpinner );
 
 		/*
 		 * Add flow threshold.
@@ -171,7 +138,6 @@ public class AdvancedOmniposeDetectorConfigurationPanel extends OmniposeDetector
 		flowThresholdEl.update();
 		cellProbThresholdEl.set( ( double ) settings.get( KEY_CELL_PROB_THRESHOLD ) );
 		cellProbThresholdEl.update();
-		cmbboxNbClasses.setSelectedIndex( ( int ) settings.get( KEY_NB_CLASSES ) );
 	}
 
 	@Override
@@ -180,7 +146,6 @@ public class AdvancedOmniposeDetectorConfigurationPanel extends OmniposeDetector
 		final Map< String, Object > settings = super.getSettings();
 		settings.put( KEY_FLOW_THRESHOLD, flowThresholdEl.get() );
 		settings.put( KEY_CELL_PROB_THRESHOLD, cellProbThresholdEl.get() );
-		settings.put( KEY_NB_CLASSES, cmbboxNbClasses.getSelectedIndex() + 2 );
 		return settings;
 	}
 }

--- a/src/main/java/fiji/plugin/trackmate/omnipose/advanced/AdvancedOmniposeDetectorFactory.java
+++ b/src/main/java/fiji/plugin/trackmate/omnipose/advanced/AdvancedOmniposeDetectorFactory.java
@@ -83,16 +83,7 @@ public class AdvancedOmniposeDetectorFactory< T extends RealType< T > & NativeTy
 			+ "<p>"
 			+ "Documentation for this module "
 			+ "<a href=\"https://imagej.net/plugins/trackmate/trackmate-advanced-omnipose\">on the ImageJ Wiki</a>."
-			+ "</html>";
-
-         /**
-	 * The key to the parameter that store the output number of classes. 
-	 */
-        public static final String KEY_NB_CLASSES = "NB_CLASSES";
-
-	public static final Integer DEFAULT_NB_CLASSES = Integer.valueOf( 0 );
-
-        
+			+ "</html>";        
 	/*
 	 * METHODS
 	 */
@@ -120,7 +111,6 @@ public class AdvancedOmniposeDetectorFactory< T extends RealType< T > & NativeTy
 
 		final double flowThreshold = ( Double ) settings.get( KEY_FLOW_THRESHOLD );
 		final double cellProbThreshold = ( Double ) settings.get( KEY_CELL_PROB_THRESHOLD );
-                final int nbClasses = (Integer) settings.get( KEY_NB_CLASSES );
 
 		final AdvancedOmniposeSettings cellposeSettings = AdvancedOmniposeSettings
 				.create()
@@ -134,7 +124,6 @@ public class AdvancedOmniposeDetectorFactory< T extends RealType< T > & NativeTy
 				.simplifyContours( simplifyContours )
 				.flowThreshold( flowThreshold )
 				.cellProbThreshold( cellProbThreshold )
-                                .nbClasses(nbClasses)
 				.get();
 
 		// Logger.
@@ -152,7 +141,6 @@ public class AdvancedOmniposeDetectorFactory< T extends RealType< T > & NativeTy
 		final StringBuilder errorHolder = new StringBuilder();
 		boolean ok = writeAttribute( settings, element, KEY_FLOW_THRESHOLD, Double.class, errorHolder );
 		ok = ok && writeAttribute( settings, element, KEY_CELL_PROB_THRESHOLD, Double.class, errorHolder );
-                ok = ok && writeAttribute( settings, element, KEY_NB_CLASSES, Integer.class, errorHolder );
 		if ( !ok )
 			errorMessage = errorHolder.toString();
 		return ok;
@@ -173,7 +161,6 @@ public class AdvancedOmniposeDetectorFactory< T extends RealType< T > & NativeTy
 		ok = ok && readBooleanAttribute( element, settings, KEY_SIMPLIFY_CONTOURS, errorHolder );
 		ok = ok && readDoubleAttribute( element, settings, KEY_FLOW_THRESHOLD, errorHolder );
 		ok = ok && readDoubleAttribute( element, settings, KEY_CELL_PROB_THRESHOLD, errorHolder );
-                ok = ok && readDoubleAttribute( element, settings, KEY_NB_CLASSES, errorHolder );
 
 		// Read model.
 		final String str = element.getAttributeValue( KEY_OMNIPOSE_MODEL );
@@ -199,7 +186,6 @@ public class AdvancedOmniposeDetectorFactory< T extends RealType< T > & NativeTy
 		final Map< String, Object > settings = super.getDefaultSettings();
 		settings.put( KEY_FLOW_THRESHOLD, DEFAULT_FLOW_THRESHOLD );
 		settings.put( KEY_CELL_PROB_THRESHOLD, DEFAULT_CELL_PROB_THRESHOLD );
-                settings.put( KEY_NB_CLASSES, DEFAULT_NB_CLASSES );
 		return settings;
 	}
 
@@ -218,7 +204,6 @@ public class AdvancedOmniposeDetectorFactory< T extends RealType< T > & NativeTy
 		ok = ok & checkParameter( settings, KEY_SIMPLIFY_CONTOURS, Boolean.class, errorHolder );
 		ok = ok & checkParameter( settings, KEY_FLOW_THRESHOLD, Double.class, errorHolder );
 		ok = ok & checkParameter( settings, KEY_CELL_PROB_THRESHOLD, Double.class, errorHolder );
-                ok = ok & checkParameter( settings, KEY_NB_CLASSES, Integer.class, errorHolder );
 
 		// If we have a logger, test it is of the right class.
 		final Object loggerObj = settings.get( KEY_LOGGER );
@@ -241,8 +226,7 @@ public class AdvancedOmniposeDetectorFactory< T extends RealType< T > & NativeTy
 				KEY_OMNIPOSE_CUSTOM_MODEL_FILEPATH,
 				KEY_LOGGER,
 				KEY_FLOW_THRESHOLD,
-				KEY_CELL_PROB_THRESHOLD,
-                                KEY_NB_CLASSES);
+				KEY_CELL_PROB_THRESHOLD);
 		ok = ok & checkMapKeys( settings, mandatoryKeys, optionalKeys, errorHolder );
 		if ( !ok )
 			errorMessage = errorHolder.toString();

--- a/src/main/java/fiji/plugin/trackmate/omnipose/advanced/AdvancedOmniposeSettings.java
+++ b/src/main/java/fiji/plugin/trackmate/omnipose/advanced/AdvancedOmniposeSettings.java
@@ -11,8 +11,6 @@ public class AdvancedOmniposeSettings extends OmniposeSettings
 	private final double flowThreshold;
 
 	private final double cellProbThreshold;
-        
-        private final int nbClasses;
 
 	public AdvancedOmniposeSettings(
 			final String omniposePythonPath,
@@ -24,13 +22,11 @@ public class AdvancedOmniposeSettings extends OmniposeSettings
 			final boolean useGPU,
 			final boolean simplifyContours,
 			final double flowThreshold,
-			final double cellProbThreshold,
-                        final int nbClasses)
+			final double cellProbThreshold)
 	{
 		super( omniposePythonPath, model, customModelPath, chan, chan2, diameter, useGPU, simplifyContours );
 		this.flowThreshold = flowThreshold;
 		this.cellProbThreshold = cellProbThreshold;
-                this.nbClasses = nbClasses;
 	}
 
 	@Override
@@ -45,10 +41,7 @@ public class AdvancedOmniposeSettings extends OmniposeSettings
 		 */
 		cmd.add( "--mask_threshold" );
 		cmd.add( String.valueOf( cellProbThreshold ) );
-                
-                cmd.add( "--nclasses" );
-		cmd.add( String.valueOf( nbClasses ) );
-                
+                               
                 return Collections.unmodifiableList( cmd );
 	}
 
@@ -63,8 +56,6 @@ public class AdvancedOmniposeSettings extends OmniposeSettings
 		private double flowThreshold = 0.4;
 
 		private double cellProbThreshold = 0.0;
-                
-                private int nbClasses = 4;
 
 		public Builder flowThreshold( final double flowThreshold )
 		{
@@ -77,13 +68,7 @@ public class AdvancedOmniposeSettings extends OmniposeSettings
 			this.cellProbThreshold = cellProbThreshold;
 			return this;
 		}
-                
-                public Builder nbClasses( final int nbClasses )
-		{
-			this.nbClasses = nbClasses;
-			return this;
-		}
-                                
+
 		@Override
 		public Builder channel1( final int ch )
 		{
@@ -153,8 +138,7 @@ public class AdvancedOmniposeSettings extends OmniposeSettings
 					useGPU,
 					simplifyContours,
 					flowThreshold,
-					cellProbThreshold,
-                                        nbClasses);
+					cellProbThreshold);
 		}
 	}
 }


### PR DESCRIPTION
- Remove --verbose in cmd, as it causes Omnipose to crash when frames have no detections. Wasn't fixed in Omnipose version 1.0.6
- Add --nchan argument set to 1 to use custom models trained on single-channel images
- Add --nclasses arguments to be able to use custom Omnipose models with different nclasses values. By default, --nclasses is set to 2, as in the code of Omnipose for training branch. If the python process returns an error, we parse the python output error and guess the value for --nclasses in accordance (based on the tensor size of the biases for the last output layer of the model). We then build a new command and call a new python process with the updated command.
- Add a log message to the logger if the pretrained model path is incorrect